### PR TITLE
Remove unused dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,9 +18,5 @@
         "espressif32",
         "native"
     ],
-    "headers": "M5UnitSynth.h",
-    "dependencies": {
-        "M5Unified": "*",
-        "M5GFX": "*"
-    }
+    "headers": "M5UnitSynth.h"
 }

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,3 @@ category=Display
 url=https://github.com/m5stack/M5Unit-Synth.git
 architectures=esp32
 includes=M5UnitSynth.h
-depends=M5Unified,M5GFX


### PR DESCRIPTION
Removed unused dependencies on M5Unified and M5GFX from `library.json` and `library.properties`