### PR TITLE
add setExpression(channel, expression) function

### DIFF
--- a/src/M5UnitSynth.cpp
+++ b/src/M5UnitSynth.cpp
@@ -74,6 +74,12 @@ void M5UnitSynth::setVolume(uint8_t channel, uint8_t level) {
     sendCMD(CMD_CONTROL_CHANGE, sizeof(CMD_CONTROL_CHANGE));
 }
 
+void M5UnitSynth::setExpression(uint8_t channel, uint8_t expression) {
+    uint8_t CMD_CONTROL_CHANGE[] = {
+        (uint8_t)(MIDI_CMD_CONTROL_CHANGE | (channel & 0x0f)), 0x0b, expression};
+    sendCMD(CMD_CONTROL_CHANGE, sizeof(CMD_CONTROL_CHANGE));
+}
+
 void M5UnitSynth::setReverb(uint8_t channel, uint8_t program, uint8_t level,
                             uint8_t delayfeedback) {
     uint8_t CMD_CONTROL_CHANGE_1[] = {

--- a/src/M5UnitSynth.h
+++ b/src/M5UnitSynth.h
@@ -51,6 +51,8 @@ class M5UnitSynth {
 
     void setMasterVolume(uint8_t level);             // 0-127
     void setVolume(uint8_t channel, uint8_t level);  // 0-127
+    
+    void setExpression(uint8_t channel, uint8_t expression);  // 0-127
 
     void setReverb(uint8_t channel, uint8_t program, uint8_t level,
                    uint8_t delayfeedback);


### PR DESCRIPTION
added setExpression(channel, expression) function to M5UnitSynth class.
It sends the Expression message (MIDI Control Change #11).